### PR TITLE
fix: reject_special_keys raises wrong error for datetime.datetime keys

### DIFF
--- a/src/remarshal/document.py
+++ b/src/remarshal/document.py
@@ -112,12 +112,14 @@ def reject_special_keys(key: Any) -> Any:
         msg = "boolean key"
         raise TypeError(msg)
 
-    if isinstance(key, datetime.date):
-        msg = "date key"
-        raise TypeError(msg)
-
+    # datetime.datetime is a subclass of datetime.date, so check the more
+    # specific type first to produce the correct error message.
     if isinstance(key, datetime.datetime):
         msg = "date-time key"
+        raise TypeError(msg)
+
+    if isinstance(key, datetime.date):
+        msg = "date key"
         raise TypeError(msg)
 
     if isinstance(key, datetime.time):

--- a/tests/test_remarshal.py
+++ b/tests/test_remarshal.py
@@ -19,7 +19,12 @@ import cbor2  # type: ignore
 import pytest
 
 import remarshal
-from remarshal.document import TaggedValue, envelopes_to_tags, tags_to_envelopes
+from remarshal.document import (
+    TaggedValue,
+    envelopes_to_tags,
+    reject_special_keys,
+    tags_to_envelopes,
+)
 from remarshal.main import (
     Defaults,
     FormatOptions,
@@ -1166,6 +1171,35 @@ class TestTagConversion:
     def test_round_trip_is_identity(self) -> None:
         doc = {"a": TaggedValue("!secret", {"b": TaggedValue("!inner", [1, 2])})}
         assert envelopes_to_tags(tags_to_envelopes(doc)) == doc
+
+
+class TestRejectSpecialKeys:
+    def test_datetime_key_raises_datetime_error(self) -> None:
+        # datetime.datetime is a subclass of datetime.date; the more specific
+        # check must come first so the error message is accurate.
+        dt = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        with pytest.raises(TypeError, match="date-time key"):
+            reject_special_keys(dt)
+
+    def test_date_key_raises_date_error(self) -> None:
+        with pytest.raises(TypeError, match="date key"):
+            reject_special_keys(datetime.date(2024, 1, 1))
+
+    def test_time_key_raises_time_error(self) -> None:
+        with pytest.raises(TypeError, match="time key"):
+            reject_special_keys(datetime.time(12, 0, 0))
+
+    def test_bool_key_raises_boolean_error(self) -> None:
+        key = True
+        with pytest.raises(TypeError, match="boolean key"):
+            reject_special_keys(key)
+
+    def test_none_key_raises_null_error(self) -> None:
+        with pytest.raises(TypeError, match="null key"):
+            reject_special_keys(None)
+
+    def test_string_key_passes_through(self) -> None:
+        assert reject_special_keys("hello") == "hello"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bug

`reject_special_keys` in `document.py` checks `isinstance(key, datetime.date)` before `isinstance(key, datetime.datetime)`. Because `datetime.datetime` is a subclass of `datetime.date`, the `datetime.date` branch fires first for datetime values, producing the misleading error message `"date key"` instead of the correct `"date-time key"`.

## Reproduction

```python
import datetime
from remarshal.document import reject_special_keys

reject_special_keys(datetime.datetime(2024, 1, 1, 12, 0, 0))
# TypeError: date key      ← wrong; should be "date-time key"
```

The same mismatch surfaces in the public-facing error from `remarshal` and friends when a YAML document with a datetime key is converted without `--stringify`.

## Fix

Swap the two `isinstance` checks so the more specific `datetime.datetime` test comes before `datetime.date`. Add a regression test for each special key type that asserts the exact error message.