### PR TITLE
fix: -p/--preserve-key-order no longer eats the next argv token (#68)

### DIFF
--- a/src/remarshal/main.py
+++ b/src/remarshal/main.py
@@ -355,6 +355,7 @@ def _parse_command_line(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "-p",
         "--preserve-key-order",
+        action="store_true",
         help=argparse.SUPPRESS,
     )
 

--- a/tests/test_remarshal.py
+++ b/tests/test_remarshal.py
@@ -611,6 +611,15 @@ class TestRemarshal:
         args = _parse_command_line([sys.argv[0], "input.yaml", "output.yaml"])
         assert args.expand_aliases is False
 
+    def test_preserve_key_order_flag_does_not_consume_next_arg(self) -> None:
+        # -p/--preserve-key-order is a hidden no-op kept for backward
+        # compatibility; it must not swallow the following positional arg.
+        for flag in ("-p", "--preserve-key-order"):
+            args = _parse_command_line([sys.argv[0], flag, "input.json", "output.toml"])
+            assert args.preserve_key_order is True
+            assert args.input == "input.json"
+            assert args.output == "output.toml"
+
     def test_run_no_args(self) -> None:
         with pytest.raises(SystemExit) as cm:
             run(sys.argv[0])


### PR DESCRIPTION
## Problem
Fixes #68. `-p`/`--preserve-key-order` is declared without `action="store_true"`, so argparse treats it as value-taking and it silently eats the next argv token. `remarshal -p in.json out.toml` consumes `in.json` as the value of `-p`, leaves `out.toml` as the input file, and defaults output to stdout — no error. Confirmed on master HEAD 54be2aa.

## Root cause
`src/remarshal/main.py:355-359`. The flag used to be `action='store_true'` (added in #20, 2019), back when it was a real feature. It's now a hidden `help=argparse.SUPPRESS` back-compat no-op (dict key order is preserved by default since Python 3.7), but `action="store_true"` was dropped along the way, leaving argparse's value-taking default in place. The sibling deprecated flag `--expand-aliases` a few lines down kept `action="store_true"` correctly.

## Fix
Add `action="store_true"` back to the `-p`/`--preserve-key-order` `add_argument()` call. 1 line changed in `src/remarshal/main.py`. `preserve_key_order` isn't read anywhere in `src/`, so restoring `store_true` has no other behavioral effect beyond stopping the argv-eating.

## How to test
```
$ git stash push -- src/remarshal/main.py   # revert only the fix
$ uv run pytest tests/test_remarshal.py -k test_preserve_key_order_flag_does_not_consume_next_arg -v
...
FAILED tests/test_remarshal.py::TestRemarshal::test_preserve_key_order_flag_does_not_consume_next_arg
1 failed, 140 deselected

$ git stash pop   # restore the fix
$ uv run pytest tests/test_remarshal.py -k test_preserve_key_order_flag_does_not_consume_next_arg -v
...
PASSED
1 passed, 140 deselected

$ uv run pytest   # full suite
196 passed
```
Also clean on `ruff check`, `ruff format --check`, and `pyright`.

## Backward compatibility
No breaking changes. `-p`/`--preserve-key-order` remains a hidden no-op; it just stops consuming the next argument.

---
Assisted-by: Claude (code generation, reviewed and tested locally)
